### PR TITLE
Merge conf.py back to master

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 import os
 import sys
 #sys.path.insert(0, os.path.abspath('../LSDPlottingTools/'))
-sys.path.append(os.path.join(os.path.dirname(__name__), '..'))
+sys.path.append(os.path.join(os.path.dirname(__name__), '../LSDPlottingTools'))
 
 from mock import Mock as MagicMock
 #from unittest.mock import MagicMock
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['numpy', 'gdal', 'osgeo', 'osgeo.gdal']
+MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ class Mock(MagicMock):
 
 MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
-               'matplotlib.colors']
+               'matplotlib.colors', 'matplotlib.image']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
+MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
+MOCK_MODULES = ['pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal']
+MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
+MOCK_MODULES = ['LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ class Mock(MagicMock):
 
 MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
-               'matplotlib.colors', 'matplotlib.image']
+               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst']
+MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'matplotlib', 'matplotlib.rcParams']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ import sys
 #sys.path.insert(0, os.path.abspath('../LSDPlottingTools/'))
 sys.path.append(os.path.join(os.path.dirname(__name__), '..'))
 
-from unittest.mock import MagicMock
+from mock import Mock as MagicMock
+#from unittest.mock import MagicMock
 
 class Mock(MagicMock):
     @classmethod

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,16 @@ import sys
 #sys.path.insert(0, os.path.abspath('../LSDPlottingTools/'))
 sys.path.append(os.path.join(os.path.dirname(__name__), '..'))
 
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return MagicMock()
+
+MOCK_MODULES = ['numpy', 'gdal']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 import os
 import sys
 #sys.path.insert(0, os.path.abspath('../LSDPlottingTools/'))
-sys.path.append(os.path.join(os.path.dirname(__name__), '../LSDPlottingTools'))
+sys.path.append(os.path.join(os.path.dirname(__name__), '..'))
 
 from mock import Mock as MagicMock
 #from unittest.mock import MagicMock

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'matplotlib', 'matplotlib.rcParams']
+MOCK_MODULES = ['numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.rcParams']
+MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['numpy', 'gdal']
+MOCK_MODULES = ['numpy', 'gdal', 'osgeo', 'osgeo.gdal']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,9 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams']
+MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
+                'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
+               'matplotlib.colors']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+gdal
+numpy
+matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 numpy
 mock
+matplotlib
+scipy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 matplotlib
+mock

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-gdal
 numpy
 matplotlib

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 numpy
-matplotlib
 mock


### PR DESCRIPTION
Adds a mock list of modules to trick the build environment of readthedocs into thinking that all the non-standard modules like gdal/osgeo exist and so the rest of the modules in package can be successfully imported. Found it on the readthedocs.org troubleshooting faqs.