### PR TITLE
Fixed the docs

### DIFF
--- a/docs/LSDPlottingTools.rst
+++ b/docs/LSDPlottingTools.rst
@@ -68,6 +68,30 @@ LSDPlottingTools.cubehelix module
     :undoc-members:
     :show-inheritance:
 
+LSDPlottingTools.colours module
+---------------------------------
+
+.. automodule:: LSDPlottingTools.colours
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    
+LSDPlottingTools.labels module
+---------------------------------
+
+.. automodule:: LSDPlottingTools.labels
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+LSDPlottingTools.locationmap module
+---------------------------------
+
+.. automodule:: LSDPlottingTools.locationmap
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/docs/LSDPlottingTools.rst
+++ b/docs/LSDPlottingTools.rst
@@ -36,10 +36,10 @@ LSDPlottingTools.LSDMap_GDALIO module
     :undoc-members:
     :show-inheritance:
 
-LSDPlottingTools.LSDMap_PointData module
+LSDPlottingTools.LSDMap_PointTools module
 ----------------------------------------
 
-.. automodule:: LSDPlottingTools.LSDMap_PointData
+.. automodule:: LSDPlottingTools.LSDMap_PointTools
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ class Mock(MagicMock):
 
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
-               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm']
+               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm'. 'matplotlib.gridspec']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ class Mock(MagicMock):
 
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
-               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm'. 'matplotlib.gridspec']
+               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return MagicMock()
 
-MOCK_MODULES = ['scipy','pyproj', 'LSDOSystemTools', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
+MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
                'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ class Mock(MagicMock):
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
                'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec', 'matplotlib.patches',
-               'cartopy', 'cartopy.feature', 'cartopy.crs']
+               'cartopy', 'cartopy.feature', 'cartopy.crs', 'cartopy.mpl.ticker', 'shapely', 'shapely.geometry.polygon']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ class Mock(MagicMock):
 
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
-               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec']
+               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec',
+               'cartopy', 'cartopy.feature']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,8 @@ class Mock(MagicMock):
 
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
-               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec',
-               'cartopy', 'cartopy.feature']
+               'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec', 'matplotlib.patches',
+               'cartopy', 'cartopy.feature', 'cartopy.crs']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,8 @@ class Mock(MagicMock):
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
                'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec', 'matplotlib.patches',
-               'cartopy', 'cartopy.feature', 'cartopy.crs', 'cartopy.mpl.ticker', 'shapely', 'shapely.geometry.polygon']
+               'cartopy', 'cartopy.feature', 'cartopy.crs', 'cartopy.mpl.ticker', 'shapely', 'shapely.geometry',
+               'shapely.geometry.polygon']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ class Mock(MagicMock):
 MOCK_MODULES = ['scipy','pyproj', 'numpy', 'numpy.ma', 'gdal', 'osgeo', 'osgeo.gdal', 
                 'osgeo.gdalconst', 'osgeo.gdal_array', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.rcParams',
                'matplotlib.colors', 'matplotlib.image', 'matplotlib.cm', 'matplotlib.gridspec', 'matplotlib.patches',
-               'cartopy', 'cartopy.feature', 'cartopy.crs', 'cartopy.mpl.ticker', 'shapely', 'shapely.geometry',
+               'cartopy', 'cartopy.feature', 'cartopy.crs', 'cartopy.mpl', 'cartopy.mpl.ticker', 'shapely', 'shapely.geometry',
                'shapely.geometry.polygon']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ This is the basic documentation that simply repeats information sored within the
    LSDPlottingTools
 
 
-automodule:: app
+automodule:: LSDMappingTools
 
 Indices and tables
 ==================


### PR DESCRIPTION
OK...it is not quite as 'automated' as I was originally lead to believe.

If you change the module names, you must change them in the LSDPlottingTools.rst file, same goes if you add a new module too, it must be either added manually to this file (or you can rebuild with sphinx but I think just adding the module name is easier.)

If you have external module (gdal, cartopy etc) these have to go in the 'MagicMock' class sys function in conf.py. There is a big list of module names that are from external modules that we use in LSDPlottingTools. ReadTheDocs does not have all of these modules installed in the virtualenv it creates so the MagickMock thing tricks it into thinking the modules exist. 

The weird thing is that they have to be listed in hierarchical order: e.g. ['gdal', gdal.gdal_array', 'gdal.gdal_array.someothesubmodule']. 

Also weirdly, if you use a 3rd level submodule, but not the second level one e.g. 'cartopy.mpl.patch' but not 'cartopy.mpl', you still have to add 'cartopy.mpl' to the list and in the correct order (biggest to smallest)

Isn't it so simple and automated...!