### PR TITLE
Cythonise hillshade

### DIFF
--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jan 31 11:47:22 2017
+
+An example of using the LSDMapArtist to create drape plots
+
+@author: dav
+"""
+
+from LSDPlottingTools import colours as lsdcolours
+from LSDPlottingTools import init_plotting_DV
+
+import LSDPlottingTools.LSDMap_GDALIO as LSDMap_IO
+import LSDPlottingTools.LSDMap_BasicPlotting as LSDMap_BP
+
+init_plotting_DV()
+#Directory = "/mnt/SCRATCH/Dev/LSDMappingTools/test_rasters/peak_flow_rasters/"
+Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/rainfall_maps/"
+#Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/erode_diff/Difference_UNIFORM_GRIDDED/"
+#Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/erode_diff/test_raster_diff_func/"
+BackgroundRasterName = "BoscastleElevations0.asc"
+#DrapeRasterName = "BoscastleElevDiff_UNIFORM_TLIM.bil"
+DrapeRasterName = "rainfall_totals_boscastle_downscaled.asc"
+
+raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)

--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -27,14 +27,18 @@ from LSDPlottingTools import fast_hillshade as fasthill
 import LSDPlottingTools.LSDMap_GDALIO as LSDMap_IO
 import LSDPlottingTools.LSDMap_BasicPlotting as LSDMap_BP
 
-Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/rainfall_maps/"
-BackgroundRasterName = "BoscastleElevations0.asc"
+#Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/rainfall_maps/"
+Directory = "/mnt/SCRATCH/Dev/ExampleTopoDatasets/"
+BackgroundRasterName = "SanBern.bil"
 
 raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)
 
+Cellsize = LSDMap_IO.GetGeoInfo(Directory + BackgroundRasterName)[3][1]
+print(Cellsize)
+
 # This could be tidied up (not hard coded data res)
 ncols, nrows = raster.shape
-data_res = 5.0
+data_res = Cellsize
 
 # LSDMappingTools hillshade
 hs = LSDMap_BP.Hillshade(raster)

--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -24,3 +24,5 @@ BackgroundRasterName = "BoscastleElevations0.asc"
 DrapeRasterName = "rainfall_totals_boscastle_downscaled.asc"
 
 raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)
+
+hs = LSDMap_BP.Hillshade(raster)

--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -1,32 +1,48 @@
-#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
 Created on Tue Jan 31 11:47:22 2017
 
-An example of using the LSDMapArtist to create drape plots
+An example of using the cython version of the hillshade
+algorithm from LSDTopoTools/LSDRaster, compared to the pure python
+module in LSDMappingTools.
+
+(This test version dos on-the-fly-compilation to C and then a C-lib
+but you could bundle a compiled c-object with the code for speed/convenience)
 
 @author: dav
 """
 
 import matplotlib.pyplot as plt
 
-from LSDPlottingTools import colours as lsdcolours
-from LSDPlottingTools import init_plotting_DV
+# For on the fly compilation - remove if you are pre-compiling the Cython-library
+# This MUST come before you import the C hillshade pyx file if you are doing it
+# this way.
+####################
+import pyximport
+pyximport.install()
+####################
+
+from LSDPlottingTools import fast_hillshade as fasthill
 
 import LSDPlottingTools.LSDMap_GDALIO as LSDMap_IO
 import LSDPlottingTools.LSDMap_BasicPlotting as LSDMap_BP
 
-init_plotting_DV()
-#Directory = "/mnt/SCRATCH/Dev/LSDMappingTools/test_rasters/peak_flow_rasters/"
 Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/rainfall_maps/"
-#Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/erode_diff/Difference_UNIFORM_GRIDDED/"
-#Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/erode_diff/test_raster_diff_func/"
 BackgroundRasterName = "BoscastleElevations0.asc"
-#DrapeRasterName = "BoscastleElevDiff_UNIFORM_TLIM.bil"
-DrapeRasterName = "rainfall_totals_boscastle_downscaled.asc"
 
 raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)
 
+# This could be tidied up (not hard coded data res)
+ncols, nrows = raster.shape
+data_res = 5.0
+
+# LSDMappingTools hillshade
 hs = LSDMap_BP.Hillshade(raster)
 
 plt.imshow(hs, cmap="gray")
+plt.show()
+
+#LSDRaster Cythonised version pf hillshade
+hs_nice = fasthill.Hillshade(raster, ncols, nrows, data_res)
+plt.imshow(hs_nice, cmap="gray")
+plt.show()

--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -8,6 +8,8 @@ An example of using the LSDMapArtist to create drape plots
 @author: dav
 """
 
+import matplotlib.pyplot as plt
+
 from LSDPlottingTools import colours as lsdcolours
 from LSDPlottingTools import init_plotting_DV
 
@@ -26,3 +28,5 @@ DrapeRasterName = "rainfall_totals_boscastle_downscaled.asc"
 raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)
 
 hs = LSDMap_BP.Hillshade(raster)
+
+plt.imshow(hs, cmap="gray")

--- a/LSDPlottingTools/LSDMap_VectorTools.py
+++ b/LSDPlottingTools/LSDMap_VectorTools.py
@@ -118,7 +118,7 @@ def GetPointWithinBasinsBuffered(DataDirectory,fname_prefix, basin_list = [], bu
         bounds = basin.bounds
         lengths.append(bounds[2] - bounds[0])
         lengths.append(bounds[3] - bounds[1])
-        print min(lengths)
+        print(min(lengths))
 
         # buffer with a fraction of the minimum length
         new_basin = Polygon(basin.buffer(min(lengths)*buffer_frac*-1))

--- a/LSDPlottingTools/fast_hillshade.pyx
+++ b/LSDPlottingTools/fast_hillshade.pyx
@@ -13,8 +13,8 @@ DTYPE = np.float
 # Define a compile type to DTYPE_t
 ctypedef np.int_t DTYPE_t
 
-def Hillshade(np.ndarray terrain_array, azimuth = 315, angle_altitude = 45,
-              NoDataValue = -9999, z_factor = 1, DataResolution):
+def Hillshade(np.ndarray terrain_array, cdef float azimuth = 315, cdef float angle_altitude = 45,
+              cdef float NoDataValue = -9999, cdef float z_factor = 1, cdef float DataResolution):
   """Creates a hillshade raster
 
   Args:

--- a/LSDPlottingTools/fast_hillshade.pyx
+++ b/LSDPlottingTools/fast_hillshade.pyx
@@ -1,0 +1,84 @@
+#fast_hillshade.pyx
+
+# This is cython version of the nicer looking hillshade function in the
+# LSDTopoTools core C++ libraries.
+
+# Author: DAV, 2017
+import numpy as np
+cimport numpy as np
+
+# Fix a data type for our arrays.
+DTYPE = np.float
+
+# Define a compile type to DTYPE_t
+ctypedef np.int_t DTYPE_t
+
+def Hillshade(np.ndarray terrain_array, azimuth = 315, angle_altitude = 45,
+              NoDataValue = -9999, z_factor = 1, DataResolution):
+  """Creates a hillshade raster
+
+  Args:
+      raster_file (str): The name of the raster file with path and extension
+        (Can also be numpy array of loaded data.)
+      azimuth (float): Azimuth of sunlight
+      angle_altitude (float): Angle altitude of sun
+      NoDataValue (float): The nodata value of the raster
+
+  Returns:
+      HSArray (numpy.array): The hillshade array
+
+  Author:
+      DAV, SWDG, SMM
+  """
+  assert terrain_array.dtype == DTYPE
+
+  # DAV attempting mask nodata vals
+  nodata_mask = terrain_array == NoDataValue
+  terrain_array[nodata_mask] = np.nan
+
+  HSarray = np.array(terrain_array)
+
+  cdef float zenith_rad = (90 - altitude) * M_PI / 180.0
+  cdef float azimuth_math = 360-azimuth + 90
+  if (azimuth_math >= 360.0) azimuth_math = azimuth_math - 360
+  cdef float azimuth_rad = azimuth_math * M_PI  / 180.0
+
+  cdef int i, j
+  for (i = 1; i < m - 1; ++i):
+    for (j = 1; j < n - 1; ++j):
+      cdef float slope_rad = 0
+      cdef float aspect_rad = 0
+      cdef float dzdx = 0
+      cdef float dzdy = 0
+
+      if (terrain_array[i][j] != NoDataValue):
+        dzdx = ((terrain_array[i][j+1] + 2*terrain_array[i+1][j] + terrain_array[i+1][j+1]) -
+                (terrain_array[i-1][j-1] + 2*terrain_array[i-1][j] + terrain_array[i-1][j+1]))
+                / (8 * DataResolution)
+        dzdy = ((terrain_array[i-1][j+1] + 2*terrain_array[i][j+1] + terrain_array[i+1][j+1]) -
+                (terrain_array[i-1][j-1] + 2*terrain_array[i][j-1] + terrain_array[i+1][j-1]))
+                / (8 * DataResolution)
+
+        slope_rad = np.atan(z_factor * np.sqrt((dzdx*dzdx) + (dzdy*dzdy)))
+
+        if (dzdx != 0):
+          aspect_rad = np.atan2(dzdy, (dzdx*-1))
+          if (aspect_rad < 0):
+            aspect_rad = 2*M_PI + aspect_rad
+
+        else:
+          if (dzdy > 0):
+            aspect_rad = M_PI/2
+          elif (dzdy < 0):
+            aspect_rad = 2 * M_PI - M_PI/2
+          else:
+            aspect_rad = aspect_rad
+
+        HSarray[i][j] = 255.0 * ((cos(zenith_rad) * cos(slope_rad)) +
+                        (sin(zenith_rad) * sin(slope_rad) *
+                        cos(azimuth_rad - aspect_rad)))
+
+        if (HSarray[i][j] < 0):
+          HSarray[i][j] = 0
+
+  return HSarray

--- a/LSDPlottingTools/fast_hillshade.pyx
+++ b/LSDPlottingTools/fast_hillshade.pyx
@@ -39,9 +39,11 @@ def Hillshade(np.ndarray terrain_array, int ncols, int nrows,
   nodata_mask = terrain_array == NoDataValue
   terrain_array[nodata_mask] = np.nan
 
-  HSarray = np.array(terrain_array)
+  # Ndarray best choice? Will revisit later...
+  HSarray = np.ndarray((ncols,nrows))
+  HSarray.fill(np.nan)
   
-  cdef float M_PI = 3.141
+  cdef float M_PI = np.pi
 
   cdef float zenith_rad = (90 - angle_altitude) * M_PI / 180.0
   cdef float azimuth_math = 360-azimuth + 90
@@ -57,24 +59,24 @@ def Hillshade(np.ndarray terrain_array, int ncols, int nrows,
   cdef int i, j
   i = 1
   j = 1
+  # For loop necessary? Revisit...
   for i in range(0, ncols - 1):
     for j in range(0, nrows - 1):
-
-      if (terrain_array[i][j] != NoDataValue):
+        # No need to check nodata value every iter, they are nans handled by numpy?
         dzdx = (((terrain_array[i][j+1] + 2*terrain_array[i+1][j] + terrain_array[i+1][j+1]) -
                 (terrain_array[i-1][j-1] + 2*terrain_array[i-1][j] + terrain_array[i-1][j+1]))
                 / (8 * DataResolution))
         dzdy = (((terrain_array[i-1][j+1] + 2*terrain_array[i][j+1] + terrain_array[i+1][j+1]) -
                 (terrain_array[i-1][j-1] + 2*terrain_array[i][j-1] + terrain_array[i+1][j-1]))
                 / (8 * DataResolution))
-
+    
         slope_rad = np.arctan(z_factor * np.sqrt((dzdx*dzdx) + (dzdy*dzdy)))
-
+    
         if (dzdx != 0):
           aspect_rad = np.arctan2(dzdy, (dzdx*-1))
           if (aspect_rad < 0):
             aspect_rad = 2*M_PI + aspect_rad
-
+    
         else:
           if (dzdy > 0):
             aspect_rad = M_PI/2
@@ -82,11 +84,12 @@ def Hillshade(np.ndarray terrain_array, int ncols, int nrows,
             aspect_rad = 2 * M_PI - M_PI/2
           else:
             aspect_rad = aspect_rad
-
+        # Same comment as above...for loop assignment? Use array instead of ndarray
+        # and then whole  array operation
         HSarray[i][j] = 255.0 * ((np.cos(zenith_rad) * np.cos(slope_rad)) +
                         (np.sin(zenith_rad) * np.sin(slope_rad) *
                         np.cos(azimuth_rad - aspect_rad)))
-
+        # Necessary?
         if (HSarray[i][j] < 0):
           HSarray[i][j] = 0
 


### PR DESCRIPTION
This implements the nicer-looking[_citation-needed]_ LSDRaster hillshade algorithm in Cython (a superset of Python, but with C-extensions that compile into a C library, either at runtime, or you can precompile the Cython code to a binary (.so or .a file) before deploying it. (So it should be fast-ish - at least as fast as the C++ code in LSDRaster). Not done any speed-up benchmark tests yet.

Example output below:

## Current LSDMappingTools hillshade algorithm
![python-hillshade-mappingtools-current](https://user-images.githubusercontent.com/10996571/27658296-734ff984-5c47-11e7-8a35-76fc397b9223.png)

## LSDRaster hillshade algorithm, implemented here in Cython
![c-hillshade-lsd](https://user-images.githubusercontent.com/10996571/27658299-76210108-5c47-11e7-8a60-3d2dc4224c54.png)

