### PR TITLE
Optimise cython hillshade

### DIFF
--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -29,7 +29,7 @@ import LSDPlottingTools.LSDMap_BasicPlotting as LSDMap_BP
 
 #Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/rainfall_maps/"
 Directory = "/mnt/SCRATCH/Dev/ExampleTopoDatasets/"
-BackgroundRasterName = "indian_creek.bil"
+BackgroundRasterName = "SanBern.bil"
 
 raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)
 
@@ -45,9 +45,9 @@ data_res = Cellsize
 hs = LSDMap_BP.Hillshade(raster)
 
 plt.imshow(hs, cmap="gray")
-#plt.show()
+plt.show()
 
 #LSDRaster Cythonised version pf hillshade
 hs_nice = fasthill.Hillshade(raster, data_res, NoDataValue=NoDataValue)
 plt.imshow(hs_nice, cmap="gray")
-#plt.show()
+plt.show()

--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -29,11 +29,12 @@ import LSDPlottingTools.LSDMap_BasicPlotting as LSDMap_BP
 
 #Directory = "/mnt/SCRATCH/Analyses/HydrogeomorphPaper/rainfall_maps/"
 Directory = "/mnt/SCRATCH/Dev/ExampleTopoDatasets/"
-BackgroundRasterName = "SanBern.bil"
+BackgroundRasterName = "indian_creek.bil"
 
 raster = LSDMap_IO.ReadRasterArrayBlocks(Directory + BackgroundRasterName)
 
 Cellsize = LSDMap_IO.GetGeoInfo(Directory + BackgroundRasterName)[3][1]
+NoDataValue = LSDMap_IO.getNoDataValue(Directory + BackgroundRasterName)
 print(Cellsize)
 
 # This could be tidied up (not hard coded data res)
@@ -47,6 +48,6 @@ plt.imshow(hs, cmap="gray")
 plt.show()
 
 #LSDRaster Cythonised version pf hillshade
-hs_nice = fasthill.Hillshade(raster, ncols, nrows, data_res)
+hs_nice = fasthill.Hillshade(raster, data_res, NoDataValue=NoDataValue)
 plt.imshow(hs_nice, cmap="gray")
 plt.show()

--- a/HillshadeComparison.py
+++ b/HillshadeComparison.py
@@ -45,9 +45,9 @@ data_res = Cellsize
 hs = LSDMap_BP.Hillshade(raster)
 
 plt.imshow(hs, cmap="gray")
-plt.show()
+#plt.show()
 
 #LSDRaster Cythonised version pf hillshade
 hs_nice = fasthill.Hillshade(raster, data_res, NoDataValue=NoDataValue)
 plt.imshow(hs_nice, cmap="gray")
-plt.show()
+#plt.show()

--- a/LSDPlottingTools/LSDMap_VectorTools.py
+++ b/LSDPlottingTools/LSDMap_VectorTools.py
@@ -5,6 +5,7 @@
 ## FJC
 ## 26/06/17
 ##=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from . import LSDMap_GDALIO as LSDMap_IO
@@ -18,7 +19,7 @@ def GetBasinOutlines(DataDirectory, basins_fname):
     """
     This function takes in the raster of basins and gets a dict of basin polygons,
     where the key is the basin key and the value is a shapely polygon of the basin.
-    
+
     IMPORTANT: In this case the "basin key" is usually the junction number:
         this function will use the raster values as keys and in general
         the basin rasters are output based on junction indices rather than keys
@@ -34,8 +35,8 @@ def GetBasinOutlines(DataDirectory, basins_fname):
     """
     # read in the basins raster
     this_fname = basins_fname.split('.')
-    print basins_fname
-    print this_fname[0]
+    print(basins_fname)
+    print(this_fname[0])
     OutputShapefile = this_fname[0]+'.shp'
 
     # polygonise the raster
@@ -48,7 +49,7 @@ def GetBasinCentroids(DataDirectory, basins_fname):
     key is the basin key and the value is the shapely point of the centroid
 
     In most cases the "basin key" is actually the junction index: it comes
-    from the basins labeled within the basin raster, which is output with 
+    from the basins labeled within the basin raster, which is output with
     junction indices rather than junction keys
 
     Args:
@@ -75,9 +76,9 @@ def GetPointWithinBasins(DataDirectory,basins_fname):
     This function takes in the raster of basin and returns a dict where the
     key is the basin key and the value is a shapely point that is representative
     of the basin (guaranteed to be within the polygon)
-    
+
     In most cases the "basin key" is actually the junction index: it comes
-    from the basins labeled within the basin raster, which is output with 
+    from the basins labeled within the basin raster, which is output with
     junction indices rather than junction keys
 
     Args:
@@ -107,7 +108,7 @@ def GetPointWithinBasinsBuffered(DataDirectory,basins_fname, basin_list = [], bu
     is a shapely point that is the centroid of the buffered basin.
 
     In most cases the "basin key" is actually the junction index: it comes
-    from the basins labeled within the basin raster, which is output with 
+    from the basins labeled within the basin raster, which is output with
     junction indices rather than junction keys
 
     This doesn't work at the moment - need to think of a way to specify the buffer

--- a/LSDPlottingTools/fast_hillshade.pyx
+++ b/LSDPlottingTools/fast_hillshade.pyx
@@ -1,19 +1,28 @@
 #fast_hillshade.pyx
-
 # This is cython version of the nicer looking hillshade function in the
 # LSDTopoTools core C++ libraries.
+
+# Cython rule of thumb no 1. If there are equivalent C-libraries for
+# numpy stuff, use them. (E.g. math functions)
+# Let's use the native C-libraries for math functions.
+from libc.math cimport sin, cos, sqrt, M_PI, atan, atan2
+
+import cython
+cimport cython
 
 # Author: DAV, 2017
 import numpy as np
 cimport numpy as np
 
 # Fix a data type for our arrays.
-DTYPE = np.float
-
+DTYPE = np.float64
 # Define a compile type to DTYPE_t
-ctypedef np.int_t DTYPE_t
+ctypedef np.float64_t DTYPE_t
 
-def Hillshade(np.ndarray terrain_array, int ncols, int nrows,
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nonecheck(False)
+def Hillshade(np.ndarray[DTYPE_t, ndim=2] terrain_array,
               float DataResolution, float azimuth = 315,
               float angle_altitude = 45,
               float NoDataValue = -9999, float z_factor = 1):
@@ -31,19 +40,22 @@ def Hillshade(np.ndarray terrain_array, int ncols, int nrows,
 
   Author:
       DAV, SWDG, SMM
-      
+
   """
-  assert terrain_array.dtype == DTYPE
+  #assert terrain_array.dtype == DTYPE_t
+
+  cdef unsigned int ncols = terrain_array.shape[0]
+  cdef unsigned int nrows = terrain_array.shape[1]
 
   # DAV attempting mask nodata vals
-  nodata_mask = terrain_array == NoDataValue
-  terrain_array[nodata_mask] = np.nan
+  #nodata_mask = terrain_array == NoDataValue
+  #terrain_array[nodata_mask] = np.nan
 
   # Ndarray best choice? Will revisit later...
-  HSarray = np.ndarray((ncols,nrows))
+  cdef np.ndarray[DTYPE_t, ndim=2] HSarray = np.empty((ncols,nrows))
   HSarray.fill(np.nan)
-  
-  cdef float M_PI = np.pi
+
+  #cdef float M_PI = np.pi
 
   cdef float zenith_rad = (90 - angle_altitude) * M_PI / 180.0
   cdef float azimuth_math = 360-azimuth + 90
@@ -55,42 +67,41 @@ def Hillshade(np.ndarray terrain_array, int ncols, int nrows,
   cdef float aspect_rad = 0
   cdef float dzdx = 0
   cdef float dzdy = 0
-
-  cdef int i, j
-  i = 1
-  j = 1
+  cdef int i, j = 0
   # For loop necessary? Revisit...
+
   for i in range(0, ncols - 1):
     for j in range(0, nrows - 1):
-        # No need to check nodata value every iter, they are nans handled by numpy?
-        dzdx = (((terrain_array[i][j+1] + 2*terrain_array[i+1][j] + terrain_array[i+1][j+1]) -
-                (terrain_array[i-1][j-1] + 2*terrain_array[i-1][j] + terrain_array[i-1][j+1]))
-                / (8 * DataResolution))
-        dzdy = (((terrain_array[i-1][j+1] + 2*terrain_array[i][j+1] + terrain_array[i+1][j+1]) -
-                (terrain_array[i-1][j-1] + 2*terrain_array[i][j-1] + terrain_array[i+1][j-1]))
-                / (8 * DataResolution))
-    
-        slope_rad = np.arctan(z_factor * np.sqrt((dzdx*dzdx) + (dzdy*dzdy)))
-    
-        if (dzdx != 0):
-          aspect_rad = np.arctan2(dzdy, (dzdx*-1))
-          if (aspect_rad < 0):
-            aspect_rad = 2*M_PI + aspect_rad
-    
-        else:
-          if (dzdy > 0):
-            aspect_rad = M_PI/2
-          elif (dzdy < 0):
-            aspect_rad = 2 * M_PI - M_PI/2
+        if terrain_array[i, j] != NoDataValue:
+          # No need to check nodata value every iter, they are nans handled by numpy?
+          dzdx = (((terrain_array[i, j+1] + 2*terrain_array[i+1, j] + terrain_array[i+1, j+1]) -
+                  (terrain_array[i-1, j-1] + 2*terrain_array[i-1, j] + terrain_array[i-1, j+1]))
+                  / (8 * DataResolution))
+          dzdy = (((terrain_array[i-1, j+1] + 2*terrain_array[i, j+1] + terrain_array[i+1, j+1]) -
+                  (terrain_array[i-1, j-1] + 2*terrain_array[i, j-1] + terrain_array[i+1, j-1]))
+                  / (8 * DataResolution))
+
+          slope_rad = atan(z_factor * sqrt((dzdx * dzdx) + (dzdy * dzdy)))
+
+          if (dzdx != 0):
+            aspect_rad = atan2(dzdy, (dzdx*-1))
+            if (aspect_rad < 0):
+              aspect_rad = 2 * M_PI + aspect_rad
+
           else:
-            aspect_rad = aspect_rad
-        # Same comment as above...for loop assignment? Use array instead of ndarray
-        # and then whole  array operation
-        HSarray[i][j] = 255.0 * ((np.cos(zenith_rad) * np.cos(slope_rad)) +
-                        (np.sin(zenith_rad) * np.sin(slope_rad) *
-                        np.cos(azimuth_rad - aspect_rad)))
-        # Necessary?
-        if (HSarray[i][j] < 0):
-          HSarray[i][j] = 0
+            if (dzdy > 0):
+              aspect_rad = M_PI / 2
+            elif (dzdy < 0):
+              aspect_rad = 2 * M_PI - M_PI / 2
+            else:
+              aspect_rad = aspect_rad
+          # Same comment as above...for loop assignment? Use array instead of ndarray
+          # and then whole  array operation
+          HSarray[i, j] = 255.0 * ((cos(zenith_rad) * cos(slope_rad)) +
+                          (sin(zenith_rad) * sin(slope_rad) *
+                          cos(azimuth_rad - aspect_rad)))
+          # Necessary?
+          if (HSarray[i, j] < 0):
+            HSarray[i, j] = 0
 
   return HSarray


### PR DESCRIPTION
This makes it **1300%** faster

LSDRaster style hillshade in previous PR #14 
`indian_creek.bil: 1m 11s`

LSDRaster style hillshade in this PR
`indian_creek.bil: 5.2 s`

(Had to change a print statement in @fclubb's `LSDMap_VectorTools.py` but it shouldn't break anything.)